### PR TITLE
Account for no path matches in grep

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ filter_paths() {
     local _PATH_REGEX
     _PATH_REGEX=$1
 
-    grep -o -P "$_PATH_REGEX"
+    grep -o -P "$_PATH_REGEX" || true
 }
 
 main() {


### PR DESCRIPTION
Currently, if no paths match the provided regex, `set -e` will cause an exit when `grep` returns a non-zero exit code.