### PR TITLE
Ensure baseRef value passed to entrypoint.sh is valid

### DIFF
--- a/entrypoint.js
+++ b/entrypoint.js
@@ -39,8 +39,7 @@ Toolkit.run(async tools => {
   }
 
   for (i = 0; i < PRs.length; i++) {
-    const base_ref = 'origin/'+baseRef;
-    const pr_ref = 'origin/'+PRs[i].head.ref;
+    const prRef = 'origin/' + PRs[i].head.ref;
     const sha = PRs[i].head.sha;
 
     let createStatus = async (state) => {
@@ -54,11 +53,11 @@ Toolkit.run(async tools => {
     };
 
     try {
-      const result = await tools.runInWorkspace('/entrypoint.sh', [base_ref, pr_ref, path]);
-      tools.log.success(pr_ref);
+      await tools.runInWorkspace('/entrypoint.sh', [baseRef, prRef, path]);
+      tools.log.success(prRef);
       await createStatus("success");
     } catch (error) {
-      tools.log.error(pr_ref);
+      tools.log.error(prRef);
       tools.log.error(error.stdout);
       await createStatus("failure");
     }


### PR DESCRIPTION
Currently, the following is passed to entrypoint.sh, which throws an error:

```
./entrypoint.sh origin/refs/heads/master origin/nessex-add-check-master-action '.*'
fatal: Not a valid object name origin/refs/heads/master
```

It seems like there was a difference between the ref stored in the payload and the ref stored in `GITHUB_REF`. One has `refs/heads/` and the other doesn't.

CircleCI also differs from GitHub Actions here, but it's solvable with `--baseRef 'master'`