### PR TITLE
Add a CircleCI Dockerfile

### DIFF
--- a/Dockerfile-circleci
+++ b/Dockerfile-circleci
@@ -1,0 +1,26 @@
+FROM circleci/node:12.0-stretch
+
+LABEL "com.github.actions.name"="check master"
+LABEL "com.github.actions.description"="Checks if current master has changes in paths changed in a PR"
+LABEL "com.github.actions.icon"="git-pull-request"
+LABEL "com.github.actions.color"="blue"
+
+LABEL "repository"="http://github.com/codesuki/check-master-action"
+LABEL "homepage"="http://github.com/codesuki/check-master-action"
+LABEL "maintainer"="Neri Marschik <codesuki@users.noreply.github.com>"
+
+RUN apt-get update \
+        && apt-get install -y --no-install-recommends \
+        git \
+        curl \
+        ca-certificates \
+        && rm -rf /var/lib/apt/lists/*
+
+COPY package*.json ./
+RUN npm ci
+ADD entrypoint.js /entrypoint.js
+ADD entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["node", "/entrypoint.js"]
+
+WORKDIR /

--- a/Dockerfile-circleci
+++ b/Dockerfile-circleci
@@ -9,13 +9,6 @@ LABEL "repository"="http://github.com/codesuki/check-master-action"
 LABEL "homepage"="http://github.com/codesuki/check-master-action"
 LABEL "maintainer"="Neri Marschik <codesuki@users.noreply.github.com>"
 
-RUN apt-get update \
-        && apt-get install -y --no-install-recommends \
-        git \
-        curl \
-        ca-certificates \
-        && rm -rf /var/lib/apt/lists/*
-
 COPY package*.json ./
 RUN npm ci
 ADD entrypoint.js /entrypoint.js


### PR DESCRIPTION
To better support CircleCI, this adds a second Dockerfile using a CircleCI official docker image as the base. That makes a huge difference in how frequently you'll get cached docker image layers in CircleCI.

This is intended to be built alongside the current image in Docker Hub as a variant.